### PR TITLE
fix the bug of items cannot be moved after editing wall layout

### DIFF
--- a/example/js/blueprint3d.js
+++ b/example/js/blueprint3d.js
@@ -48797,8 +48797,19 @@ utils.lineLineIntersect = function(x1,y1,x2,y2, x3,y3,x4,y4) {
 // corners is an array of points with x,y attributes
 // startX and startY are start coords for raycast
 utils.pointInPolygon = function(x,y,corners,startX,startY) {
-    startX = startX || 0;
-    startY = startY || 0;
+    //startX = startX || 0;
+    //startY = startY || 0;
+    //ensure that point(startX, startY) is outside the polygon consists of corners
+    var minx = 0,
+        miny = 0;
+    if(startX === undefined || startY === undefined){
+        for (var i = 0; i < corners.length; i++) {
+            minx = Math.min(minx, corners[i].x);
+            miny = Math.min(minx, corners[i].y);
+        }
+        startX = minx - 10;
+        startY = miny - 10;
+    }
 
     var intersects = 0;
     for (var i = 0; i < corners.length; i++) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -169,8 +169,19 @@ utils.lineLineIntersect = function(x1,y1,x2,y2, x3,y3,x4,y4) {
 // corners is an array of points with x,y attributes
 // startX and startY are start coords for raycast
 utils.pointInPolygon = function(x,y,corners,startX,startY) {
-    startX = startX || 0;
-    startY = startY || 0;
+    //startX = startX || 0;
+    //startY = startY || 0;
+    //ensure that point(startX, startY) is outside the polygon consists of corners
+    var minx = 0,
+        miny = 0;
+    if(startX === undefined || startY === undefined){
+        for (var i = 0; i < corners.length; i++) {
+            minx = Math.min(minx, corners[i].x);
+            miny = Math.min(minx, corners[i].y);
+        }
+        startX = minx - 10;
+        startY = miny - 10;
+    }
 
     var intersects = 0;
     for (var i = 0; i < corners.length; i++) {


### PR DESCRIPTION
`utils.pointInPolygon` cannot always return true result if point(startX, startY) in the polygon of one room. so we have to ensure (startX, startY) is outside the polygon. My solution is to find the minx, miny and set startX, startY more smaller. We can also set startX, startY to small or large enough.