### PR TITLE
Fixed removeCorner callback

### DIFF
--- a/src/model/floorplan.ts
+++ b/src/model/floorplan.ts
@@ -139,7 +139,7 @@ module BP3D.Model {
       var corner = new Corner(this, x, y, id);
       this.corners.push(corner);
       corner.fireOnDelete(() => {
-        this.removeCorner;
+        this.removeCorner(corner);
       });
       this.new_corner_callbacks.fire(corner);
       return corner;


### PR DESCRIPTION
While playing with the repo, we found that corners weren't always being cleaned up (e.g. collapsing a square into 2 edges (i.e. to "L" shape))

In this PR:

- Fixed `removeCorner` callback to run properly